### PR TITLE
Fixing pandas version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,16 @@
 name: SIO221A-environment
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
-  - libnetcdf==4.6.1
-  - numpy==1.16.4
-  - matplotlib==3.1.0
-  - netcdf4==1.4.2
-  - xarray==0.12.1
-  - nc-time-axis==1.2.0
-  - holoviews==1.12.3
   - bokeh==1.2.0
-  - hvplot==0.4.0
   - datashader==0.7.0
-  
+  - holoviews==1.12.3
+  - hvplot==0.4.0
+  - libnetcdf==4.6.1
+  - matplotlib==3.1.0
+  - nc-time-axis==1.2.0
+  - netcdf4==1.4.2
+  - numpy==1.16.4
+  - pandas==0.24.2
+  - xarray==0.12.1


### PR DESCRIPTION
Holding pandas on 0.24.2 to avoid warning on pandas.Panel removal.